### PR TITLE
Use nativeEvent argument in onLayout instead of container.measure

### DIFF
--- a/index.js
+++ b/index.js
@@ -175,12 +175,11 @@ export default class Carousel extends Component {
     this._setUpTimer();
   }
 
-  _onLayout = () => {
-    this.container.measure((x, y, w, h) => {
-      this.setState({ size: { width: w, height: h } });
-      // remove setTimeout wrapper when https://github.com/facebook/react-native/issues/6849 is resolved.
-      setTimeout(() => this._placeCritical(this.state.currentPage), 0);
-    });
+  _onLayout = (event) => {
+    const { height, width } = event.nativeEvent.layout;
+    this.setState({ size: { width, height } });
+    // remove setTimeout wrapper when https://github.com/facebook/react-native/issues/6849 is resolved.
+    setTimeout(() => this._placeCritical(this.state.currentPage), 0);
   }
 
   _clearTimer = () => {
@@ -325,7 +324,6 @@ export default class Carousel extends Component {
     const { contents } = this.state;
 
     const containerProps = {
-      ref: (c) => { this.container = c; },
       onLayout: this._onLayout,
       style: [this.props.style],
     };


### PR DESCRIPTION
```this.container.measure``` was not returning the full ```height``` and ```width``` if the screen was in the middle of a transition. This caused a miscalculation where the full container view was not taken up. Example:
![miscalculated-layout](https://user-images.githubusercontent.com/1288966/26953760-23ff506e-4c61-11e7-98fe-bae6ff7de23d.gif)


```onLayout``` (http://facebook.github.io/react-native/releases/0.45/docs/view.html#onlayout) receives the same view's dimensions with ```event.nativeEvent.layout```. The docs suggest using those instead
(http://facebook.github.io/react-native/releases/0.45/docs/direct-manipulation.html#measure-callback).

This change sets the correct ```width``` and ```height``` and gives the expected behavior instead:
![correctly-calculated-layout](https://user-images.githubusercontent.com/1288966/26953765-2b4712bc-4c61-11e7-8ecc-f75fb3bddf26.gif)
