### PR TITLE
Reset currentPage only when out of size

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,10 +107,12 @@ export default class Carousel extends Component {
   componentWillReceiveProps(nextProps) {
     if (!isEqual(this.props.children, nextProps.children)) {
       let childrenLength = 0;
-      this.setState({ currentPage: 0 });
       if (nextProps.children) {
         const length = React.Children.count(nextProps.children);
         childrenLength = length || 1;
+      }
+      if (this.state.currentPage >= childrenLength) {
+        this.setState({ currentPage: 0 });
       }
       this.setState({ childrenLength }, () => {
         this._setUpPages().then(() => this.setState({ contents: this.pages }));


### PR DESCRIPTION
I don't anymore think we should reset the `currentPage` any time the children change.

**Example**

- children style changes (e.g. the device orientation changed and new style needs to be applied)
- componentWillReceiveProps triggers, because the props (children) changed
- isEqual fails, because the objects are not the same (they have different style props)
- Carousel flips to the 0th page

I don't think this is expected behaviour. Therefore, I think we should reset the currentPage only when it's out of bounds. I previously advocated for reseting it when someone decides to replace all children programatically, but in such situation they should probably just mount a new carousel. 