### PR TITLE
Add option to set images for arrows

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,16 @@ pageInfoTextSeparator | string | ' / ' | separator for `{currentPage}` and `{tot
 bullets | bool | false | wether to show "bullets" at the bottom of the carousel
 bulletStyle | style | null | style for each bullet
 bulletsContainerStyle | style | null | style for the bullets container
-chosenBulletStyle | stlye | null | style for the selected bullet
+chosenBulletStyle | style | null | style for the selected bullet
 **Arrows** | --- | --- | ---
 arrows | bool | false | wether to show navigation arrows for the carousel
 arrowsStyle | style | null | style for navigation arrows
 arrowsContainerStyle | style | null | style for the navigation arrows container
 leftArrowText | string / element | 'Left' | label / icon for left navigation arrow
 rightArrowText | string / element | 'Right' | label / icon for right navigation arrow
+leftArrowImage | Image source | null | image / icon for left navigation arrow
+rightArrowImage | Image source | null | image / icon for right navigation arrow
+arrowImageStyle | style | null | style for arrow images (e.g. width and height)
 
 ## Usage
 ```js

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import {
   Platform,
   StyleSheet,
   Text,
+  Image,
   ScrollView,
   TouchableOpacity,
   View,
@@ -50,6 +51,9 @@ export default class Carousel extends Component {
       PropTypes.string,
       PropTypes.element,
     ]),
+    leftArrowImage: Image.propTypes.source,
+    rightArrowImage: Image.propTypes.source,
+    arrowImageStyle: viewPropTypes.style,
     chosenBulletStyle: Text.propTypes.style,
     onAnimateNextPage: PropTypes.func,
     swipe: PropTypes.bool,
@@ -76,6 +80,9 @@ export default class Carousel extends Component {
     arrowStyle: undefined,
     leftArrowText: '',
     rightArrowText: '',
+    leftArrowImage: undefined,
+    rightArrowImage: undefined,
+    arrowImageStyle: undefined,
     onAnimateNextPage: undefined,
     swipe: true,
   };
@@ -315,15 +322,40 @@ export default class Carousel extends Component {
     if (currentPage < 1) {
       currentPage = childrenLength;
     }
+
+    if (this.props.leftArrowText && this.props.leftArrowImage) {
+      console.warn("Props leftArrowImage and leftArrowText are both defined. leftArrowImage will be used.");
+    }
+
+    if (this.props.rightArrowText && this.props.rightArrowImage) {
+      console.warn("Props rightArrowImage and rightArrowText are both defined. rightArrowImage will be used.");
+    }
+
     return (
       <View style={styles.arrows} pointerEvents="box-none">
         <View style={[styles.arrowsContainer, this.props.arrowsContainerStyle]} pointerEvents="box-none">
-          <TouchableOpacity onPress={() => this.animateToPage(this._normalizePageNumber(currentPage - 1))} style={this.props.arrowStyle}><Text>{this.props.leftArrowText ? this.props.leftArrowText : 'Left'}</Text></TouchableOpacity>
-          <TouchableOpacity onPress={() => this.animateToPage(this._normalizePageNumber(currentPage + 1))} style={this.props.arrowStyle}><Text>{this.props.rightArrowText ? this.props.rightArrowText : 'Right'}</Text></TouchableOpacity>
+          <TouchableOpacity onPress={() => this.animateToPage(this._normalizePageNumber(currentPage - 1))} style={this.props.arrowStyle}>{this.props.leftArrowImage ? this._renderLeftArrowImage() : this._renderLeftArrowText()}</TouchableOpacity>
+          <TouchableOpacity onPress={() => this.animateToPage(this._normalizePageNumber(currentPage + 1))} style={this.props.arrowStyle}>{this.props.rightArrowImage ? this._renderRightArrowImage() : this._renderRightArrowText()}</TouchableOpacity>
         </View>
       </View>
     );
   }
+
+  _renderLeftArrowText = () => (
+    <Text>{this.props.leftArrowText ? this.props.leftArrowText : 'Left'}</Text>
+  )
+
+  _renderRightArrowText = () => (
+    <Text>{this.props.rightArrowText ? this.props.rightArrowText : 'Right'}</Text>
+  )
+
+  _renderLeftArrowImage = () => (
+    <Image source={this.props.leftArrowImage} style={this.props.arrowImageStyle}/>
+  )
+
+  _renderRightArrowImage = () => (
+    <Image source={this.props.rightArrowImage} style={this.props.arrowImageStyle}/>
+  )
 
   render() {
     const { contents } = this.state;


### PR DESCRIPTION
Allows for setting arrows to images. Warns if text and image props are both set. Image takes priority.

Props added:
- `leftArrowImage`
- `rightArrowImage`
- `arrowImageStyle`