### PR TITLE
Check children's keys before resetting currentPage.

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,10 @@ export default class Carousel extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    if (!isEqual(this.props.children, nextProps.children)) {
+    const different = this.props.children.some((child, index) => {
+      return child.key !== nextProps.children[index].key;
+    })
+    if (different || this.props.children.length !== nextProps.children.length) {
       let childrenLength = 0;
       this.setState({ currentPage: 0 });
       if (nextProps.children) {


### PR DESCRIPTION
This allows the children to still be dynamic and reset the carousel
properly, but does so by checking for key equality and position, rather
than component equality.

Setting keys is a common practice for an array of React elements, so
those use cases in which an array of elements is being rendered will fit
in nicely with this scheme. Those that don't use keys will not have the
resetting behavior.

I'll leave documenting the use of keys for children to a separate
commit.

Closes #146 